### PR TITLE
Add pnpm and php support, formatting comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN apt -y install python python-pip python3 python3-pip
     # Golang
 RUN apt -y install golang
 
-    # PHP
-RUN apt -y install php php-cli php-mbstring php-xml php-common php-curl
+    # PHP, PHP-FPM & Nginx
+RUN apt -y install php php-fpm nginx php-cli php-mbstring php-xml php-common php-curl
 
     # Yarn, Pm2 and Pnpm support for AIO
 RUN npm i -g yarn pm2 pnpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -sL https://deb.nodesource.com/setup_17.x | bash - \
     && apt -y install wget \ 
     && apt -y install curl
     
-# Install basic software support
+    # Install basic software support
 RUN apt-get update && \
     apt-get install --yes software-properties-common
     
@@ -37,8 +37,8 @@ RUN apt -y install python python-pip python3 python3-pip
     # Golang
 RUN apt -y install golang
 
-#Yarn and Pm2 support for AIO
-RUN npm i -g yarn pm2
+    # Yarn, Pm2 and Pnpm support for AIO
+RUN npm i -g yarn pm2 pnpm
 
 USER container
 ENV  USER container

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt -y install python python-pip python3 python3-pip
 RUN apt -y install golang
 
     # PHP, PHP-FPM & Nginx
-RUN apt -y install php php-fpm nginx php-cli php-mbstring php-xml php-common php-curl
+RUN apt -y install php php-fpm nginx php-mysql php-cli php-mbstring php-xml php-common php-curl
 
     # Yarn, Pm2 and Pnpm support for AIO
 RUN npm i -g yarn pm2 pnpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN apt -y install python python-pip python3 python3-pip
     # Golang
 RUN apt -y install golang
 
+    # PHP
+RUN apt -y install php php-cli php-mbstring php-xml php-common php-curl
+
     # Yarn, Pm2 and Pnpm support for AIO
 RUN npm i -g yarn pm2 pnpm
 


### PR DESCRIPTION
Faced an issue when yarn and pm2 isn't installed in DBH, these changes may be useless as pnpm won't be installed just like yarn and pm2, though it works on local docker.