### PR TITLE
Add Puppeteer support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,41 @@ RUN apt -y install python python-pip python3 python3-pip
 # Golang
 RUN apt -y install golang
 
+# Install the system dependencies required for puppeteer support
+RUN apt-get install -y \
+    fonts-liberation \
+    gconf-service \
+    libappindicator1 \
+    libasound2 \
+    libatk1.0-0 \
+    libcairo2 \
+    libcups2 \
+    libfontconfig1 \
+    libgbm-dev \
+    libgdk-pixbuf2.0-0 \
+    libgtk-3-0 \
+    libicu-dev \
+    libjpeg-dev \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libpng-dev \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libxss1 \
+    libxtst6 \
+    xdg-utils
+
 # Installing NodeJS dependencies for AIO.
 RUN npm i -g yarn pm2
 


### PR DESCRIPTION
Add latest puppeteer support by adding the required system dependencies

Credit: Darker's [BetterAIO](https://github.com/Tamatoaa/BetterAIO); because I want to use the latest puppeteer version in DBH

Haven't tested because I'm too poor to afford a VPS myself and test it, but it should theoretically work