### PR TITLE
Update to use Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER danielpmc, <dan@danbot.host>
 RUN apt update \
     && apt upgrade -y \
     && apt -y install curl software-properties-common locales git \
-    && apt-get install -y default-jre \
+    && apt-get install -y openjdk-17-jre \
     && apt-get -y install liblzma-dev \
     && apt-get -y install lzma \
     && adduser container \


### PR DESCRIPTION
The current default java is java 11.
For more informations see the debian package repository (https://packages.debian.org/en/bullseye/default-jre). As you can see there, default-jre is java 11 on bullseye.

As mentioned in the Readme it should be java 17.
(17 is LTS as well as 11 is, but support for 11 ends in 8 months)