### PR TITLE
Java LTS, Python, Go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ ENV LC_ALL en_US.UTF-8
 # OpenJDK 17 LTS
 RUN apt update \
    && apt install -y libc6-i386 libc6-x32 \
-   && wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.deb -O jdk-17_linux-x64_bin.deb \
-   && apt install -y ./jdk-17_linux-x64_bin.deb \
-   && rm jdk-17_linux-x64_bin.deb
+   && wget https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.deb -O jdk-21_linux-x64_bin.deb \
+   && apt install -y ./jdk-21_linux-x64_bin.deb \
+   && rm jdk-21_linux-x64_bin.deb
    
 ENV JAVA_HOME=/usr/lib/jvm/jdk-17/
 ENV PATH=$PATH:$JAVA_HOME/bin
@@ -42,23 +42,23 @@ RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - \
 # Python 2 & 3
 RUN apt update \
    && apt -y install zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev libbz2-dev \
-   && wget https://www.python.org/ftp/python/3.11.1/Python-3.11.1.tgz \
-   && tar -xf Python-3.11.*.tgz \
-   && cd Python-3.11.1 \
+   && wget https://www.python.org/ftp/python/3.12.1/Python-3.12.1.tgz \
+   && tar -xf Python-3.12.*.tgz \
+   && cd Python-3.12.1 \
    && ./configure --enable-optimizations \
    && make -j $(nproc) \
    && make altinstall \
    && cd .. \
-   && rm -rf Python-3.11.1 \
-   && rm Python-3.11.*.tgz 
+   && rm -rf Python-3.12.1 \
+   && rm Python-3.12.*.tgz 
    
 # Upgrade Pip
 RUN apt -y install python python-pip python3-pip \
    && pip3 install --upgrade pip
 
 # Golang
-RUN curl -OL https://golang.org/dl/go1.19.5.linux-amd64.tar.gz \
-   && tar -C /usr/local -xvf go1.19.5.linux-amd64.tar.gz   
+RUN curl -OL https://golang.org/dl/go1.21.5.linux-amd64.tar.gz \
+   && tar -C /usr/local -xvf go1.21.5.linux-amd64.tar.gz   
 ENV PATH=$PATH:/usr/local/go/bin
 ENV GOROOT=/usr/local/go
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ This docker image has the following installed:
  - pm2
  - Puppeteer support
 
-2. Java 17
+2. Java JDK (`21`)
 
-3. Golang
+3. Golang (`1.21.5`)
 
-4. Python
- - Python 3.11
+4. Python (`3.12.1`)
 


### PR DESCRIPTION
Java 17 - 21, as 21 now is the LTS
Python to latest
Go to latest